### PR TITLE
Set iOS minimum deployment version to 16

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     name: "swift-blade",
     platforms: [
         .macOS(.v13),
-        .iOS(.v13),
+        .iOS(.v16),
         .tvOS(.v13),
         .watchOS(.v6),
         .macCatalyst(.v13)


### PR DESCRIPTION
The package uses some APIs that are available on iOS 16 or newer, such as `OSAllocatedUnfairLock` and parameterized protocol types.

Bumped the iOS platform to 16.